### PR TITLE
Update buildFont.sh

### DIFF
--- a/buildFont.sh
+++ b/buildFont.sh
@@ -12,8 +12,8 @@ dsp_file=$folder/$font.designspace
 
 # build the OTF version -- this requires the AFDKO toolkit
 # which is available at https://github.com/adobe-type-tools/afdko
-buildmasterotfs "$dsp_file"
-buildcff2vf "$dsp_file"
+buildmasterotfs -d "$dsp_file"
+buildcff2vf -d "$dsp_file"
 
 # extract and subroutinize the CFF2 table
 echo 'Subroutinizing' "$otf_file"


### PR DESCRIPTION
insert `-d` for `buildmasterotfs` and `buildcff2vf` commands to avoid build error with newer AFDKO